### PR TITLE
Fix license statement in ERC20.sol

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -1,6 +1,6 @@
 // Copyright (c) 2016-2017 Clearmatics Technologies Ltd
 
-// SPDX-License-Identifier: (LGPL-3.0+ AND GPL-3.0)
+// SPDX-License-Identifier: LGPL-3.0+
 
 pragma solidity ^0.4.2;
 // ERC Token Standard #20 Interface


### PR DESCRIPTION
Fix license statement in ERC20.sol.  GPL-3.0 was just a copy&paste
from code that has been removed in the meantime.