### PR TITLE
Fixes #41 - Enforce ETH, require msg.value is denomination

### DIFF
--- a/contracts/LinkableRing_tests.sol
+++ b/contracts/LinkableRing_tests.sol
@@ -13,6 +13,12 @@ contract LinkableRing_tests
 
 	LinkableRing.Data internal m_ring;
 
+	function LinkableRing_tests()
+        public
+    {
+        // Nothing ...
+    }
+
 	function testInit ()
 		public returns (bool)
 	{

--- a/contracts/Mixer.sol
+++ b/contracts/Mixer.sol
@@ -91,6 +91,13 @@ contract Mixer
     event MixerDead( bytes32 indexed ring_id );
 
 
+    function Mixer()
+        public
+    {
+        // Nothing ...
+    }
+
+
     /**
     * Lookup an unfilled/filling ring for a given token and denomination,
     * this will create a new unfilled ring if none exists. When the ring
@@ -149,6 +156,9 @@ contract Mixer
         public payable returns (bytes32)
     {      
         // TODO: verify token is a valid ERC-223 contract
+
+        require( token == 0 );
+        require( denomination == msg.value );
 
         // Denomination must be positive power of 2, e.g. only 1 bit set
         require( denomination != 0 && 0 == (denomination & (denomination - 1)) );

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -5,9 +5,9 @@ const Mixer = artifacts.require("./Mixer.sol");
 const bn256g1_tests = artifacts.require("./bn256g1_tests.sol");
 
 module.exports = (deployer) => {
-  deployer.deploy(bn256g1_tests, 4, 100000000000000000, 0);
+  deployer.deploy(bn256g1_tests);
 
-  deployer.deploy(Ring_tests, 4, 100000000000000000, 0);
+  deployer.deploy(Ring_tests);
 
-  deployer.deploy(Mixer, 4, 100000000000000000, 0);
+  deployer.deploy(Mixer);
 };


### PR DESCRIPTION
While ERC-223 support hasn't been completed yet the Mixer is Eth only, this forces the token contract to `0` and checks that `msg.value` matches the denomination.