### PR TITLE
Solidity good practices

### DIFF
--- a/contracts/ERC223ReceivingContract.sol
+++ b/contracts/ERC223ReceivingContract.sol
@@ -16,12 +16,12 @@ contract ERC223ReceivingContract {
         bytes4 sig;
     }
 
-    function tokenFallback(address _from, uint _value, bytes _data) public pure {
+    function tokenFallback(address from, uint value, bytes data) public pure {
         Token memory tkn;
-        tkn.sender = _from;
-        tkn.value = _value;
-        tkn.data = _data;
-        uint32 u = uint32(_data[3]) + (uint32(_data[2]) << 8) + (uint32(_data[1]) << 16) + (uint32(_data[0]) << 24);
+        tkn.sender = from;
+        tkn.value = value;
+        tkn.data = data;
+        uint32 u = uint32(data[3]) + (uint32(data[2]) << 8) + (uint32(data[1]) << 16) + (uint32(data[0]) << 24);
         tkn.sig = bytes4(u);
     }
 }

--- a/contracts/LinkableRing.sol
+++ b/contracts/LinkableRing.sol
@@ -6,76 +6,75 @@ pragma solidity ^0.4.19;
 
 import {bn256g1 as Curve} from './bn256g1.sol';
 
+/*
+ * This contract implements the Franklin Zhang linkable ring signature
+ * algorithm as used by the Möbius whitepaper (IACR 2017/881):
+ *
+ * - https://eprint.iacr.org/2017/881.pdf
+ *
+ * Abstract:
+ *
+ * "Cryptocurrencies allow users to securely transfer money without
+ *  relying on a trusted intermediary, and the transparency of their
+ *  underlying ledgers also enables public verifiability. This openness,
+ *  however, comes at a cost to privacy, as even though the pseudonyms
+ *  users go by are not linked to their real-world identities, all
+ *  movement of money among these pseudonyms is traceable. In this paper,
+ *  we present Möbius, an Ethereum-based tumbler or mixing service. Möbius
+ *  achieves strong notions of anonymity, as even malicious senders cannot
+ *  identify which pseudonyms belong to the recipients to whom they sent
+ *  money, and is able to resist denial-of-service attacks. It also
+ *  achieves a much lower off-chain communication complexity than all
+ *  existing tumblers, with senders and recipients needing to send only
+ *  two initial messages in order to engage in an arbitrary number of
+ *  transactions."
+ *
+ * However, this specific contract introduces the following differences
+ * in comparison to the white paper:
+ *
+ *  - P256k1 replaced with ALT_BN128 (as per EIP-213)
+ *  - The Message signed by Participants has changed
+ *  - The Ring contract is now a library
+ *  - The Ring Data stores the Token, Denomination and GUID
+ *  - Ring is a fixed size
+ *  - One SHA256 iteration per public key on verify
+ *
+ *
+ * Initialise Ring (R):
+ *
+ *   h = H(guid...)
+ *   for y in R
+ *       h = H(h, y)
+ *   m = HashToPoint(h)
+ *
+ *
+ * Verify Signature (σ):
+ *
+ *   c = 0
+ *   h = H(m, τ)
+ *   for j,c,t in σ
+ *       y = R[j]
+ *       a = g^t + y^c
+ *       b = m^t + τ^c
+ *       h = H(h, a, b)
+ *       csum += c
+ *   h == csum
+ *
+ *
+ * The Verify Signature routine differs from the Mobius whitepaper and
+ * is slightly less efficient because it performs one H() operation
+ * per public key, instead of appending all items to be hashed into a
+ * list then hashing the result.
+ *
+ * Potential Performance improvements:
+ *
+ *  - Switch to SHA3
+ *  - Reduce number of hash operations in verify (requires more memory, but only 1 hash)
+ *  - Reduce number of storage operations
+ *  - Use 'identity' precompiled contract
+**/
 
-/**
-* This contract implements the Franklin Zhang linkable ring signature
-* algorithm as used by the Möbius whitepaper (IACR 2017/881):
-*
-* - https://eprint.iacr.org/2017/881.pdf
-*
-* Abstract:
-*
-* "Cryptocurrencies allow users to securely transfer money without
-*  relying on a trusted intermediary, and the transparency of their
-*  underlying ledgers also enables public verifiability. This openness,
-*  however, comes at a cost to privacy, as even though the pseudonyms
-*  users go by are not linked to their real-world identities, all
-*  movement of money among these pseudonyms is traceable. In this paper,
-*  we present Möbius, an Ethereum-based tumbler or mixing service. Möbius
-*  achieves strong notions of anonymity, as even malicious senders cannot
-*  identify which pseudonyms belong to the recipients to whom they sent
-*  money, and is able to resist denial-of-service attacks. It also
-*  achieves a much lower off-chain communication complexity than all
-*  existing tumblers, with senders and recipients needing to send only
-*  two initial messages in order to engage in an arbitrary number of
-*  transactions."
-*
-* However, this specific contract introduces the following differences
-* in comparison to the white paper:
-*
-*  - P256k1 replaced with ALT_BN128 (as per EIP-213)
-*  - The Message signed by Participants has changed
-*  - The Ring contract is now a library
-*  - The Ring Data stores the Token, Denomination and GUID
-*  - Ring is a fixed size
-*  - One SHA256 iteration per public key on verify
-*
-*
-* Initialise Ring (R):
-*
-*   h = H(guid...)
-*   for y in R
-*       h = H(h, y)
-*   m = HashToPoint(h)
-*
-*
-* Verify Signature (σ):
-*
-*   c = 0
-*   h = H(m, τ)
-*   for j,c,t in σ
-*       y = R[j]
-*       a = g^t + y^c
-*       b = m^t + τ^c
-*       h = H(h, a, b)
-*       csum += c
-*   h == csum
-*
-*
-* The Verify Signature routine differs from the Mobius whitepaper and
-* is slightly less efficient because it performs one H() operation
-* per public key, instead of appending all items to be hashed into a
-* list then hashing the result.
-*
-* Potential Performance improvements:
-*
-*  - Switch to SHA3
-*  - Reduce number of hash operations in verify (requires more memory, but only 1 hash)
-*  - Reduce number of storage operations
-*  - Use 'identity' precompiled contract
-*/
-library LinkableRing
-{
+library LinkableRing {
     using Curve for Curve.Point;
     uint256 public constant RING_SIZE = 4;
 
@@ -85,113 +84,90 @@ library LinkableRing
         uint256[] tags;
     }
 
-
-    /**
-    * The message to be signed to withdraw from the ring once it's full
-    */
-    function Message (Data storage self)
-        internal view returns (bytes32)
-    {
-        require( IsFull(self) );
-
+    /*
+     * The message to be signed to withdraw from the ring once it's full
+    **/
+    function message(Data storage self) internal view returns (bytes32) {
+        require(isFull(self));
         return bytes32(self.hash.X);
     }
 
-
-    /**
-    * Have all possible Tags been used, one for each Public Key
-    * If the ring has not been initialized it is considered Dead.
-    */
-    function IsDead (Data storage self)
-        internal view returns (bool)
-    {
+    /*
+     * Have all possible Tags been used, one for each Public Key
+     * If the ring has not been initialized it is considered Dead.
+    **/
+    function isDead(Data storage self) internal view returns (bool) {
         return self.hash.X == 0 || (self.tags.length >= RING_SIZE && self.pubkeys.length >= RING_SIZE);
     }
 
-
-    /**
-    * Does the X component of a Public Key exist in the Ring?
-    */
-    function PubExists (Data storage self, uint256 pub_x)
-        internal view returns (bool)
-    {
-        for( uint i = 0; i < self.pubkeys.length; i++ ) {
-            if( self.pubkeys[i].X == pub_x ) {
+    /*
+     * Does the X component of a Public Key exist in the Ring?
+    **/
+    function pubExists(Data storage self, uint256 pub_x) internal view returns (bool) {
+        for(uint i = 0; i < self.pubkeys.length; i++) {
+            if(self.pubkeys[i].X == pub_x) {
                 return true;
             }
         }
         return false;
     }
 
-
-    /**
-    * Does the X component of a Tag exist?
-    */
-    function TagExists (Data storage self, uint256 pub_x)
-        internal view returns (bool)
-    {
-        for( uint i = 0; i < self.tags.length; i++ ) {
-            if( self.tags[i] == pub_x ) {
+    /*
+     * Does the X component of a Tag exist?
+    **/
+    function tagExists(Data storage self, uint256 pub_x) internal view returns (bool) {
+        for(uint i = 0; i < self.tags.length; i++) {
+            if(self.tags[i] == pub_x) {
                 return true;
             }
         }
         return false;
     }
 
-
-    function IsInitialized (Data storage self)
-        internal view returns (bool)
-    {
+    function isInitialized(Data storage self) internal view returns (bool) {
         return self.hash.X != 0;
     }
 
-
-    /**
-    * Initialise the Ring.Data structure with a token and denomination
-    */
-    function Initialize (Data storage self, bytes32 guid)
-        internal returns (bool)
-    {
-        require( uint256(guid) != 0 );
-        require( self.hash.X == 0 );
+    /*
+     * Initialise the Ring.Data structure with a token and denomination
+    **/
+    function initialize(Data storage self, bytes32 guid) internal returns (bool) {
+        require(uint256(guid) != 0);
+        require(self.hash.X == 0);
 
         self.hash.X = uint256(guid);
 
         return true;
     }
 
-
-    /**
-    * Maximum number of participants reached
-    */
-    function IsFull (Data storage self)
-        internal view returns (bool)
-    {
+    /*
+     * Maximum number of participants reached
+    **/
+    function isFull(Data storage self) internal view returns (bool) {
         return self.pubkeys.length == RING_SIZE;
     }
 
-
-    /**
-    * Add the Public Key to the ring as a ring participant
-    */
-    function AddParticipant (Data storage self, uint256 pub_x, uint256 pub_y)
+    /*
+     * Add the Public Key to the ring as a ring participant
+    **/
+    function addParticipant(Data storage self, uint256 pub_x, uint256 pub_y)
         internal returns (bool)
     {
-        require( ! IsFull(self) );
+        require(!isFull(self));
 
         // accepting duplicate public keys would lock money forever
         // as each linkable ring signature allows only one withdrawal
-        require( ! PubExists(self, pub_x) );
+        require(!pubExists(self, pub_x));
 
         Curve.Point memory pub = Curve.Point(pub_x, pub_y);
-        require( pub.IsOnCurve() );
+        require(pub.IsOnCurve());
 
         // Fill Ring with Public Keys
         //  R = {h ← H(h, y)}
         self.hash.X = uint256(sha256(self.hash.X, pub.X, pub.Y));
         self.pubkeys.push(pub);
 
-        if( IsFull(self) ) {
+        if(isFull(self)) {
             // h ← H(h, m)
             self.hash = Curve.HashToPoint(bytes32(self.hash.X));
         }
@@ -199,35 +175,31 @@ library LinkableRing
         return true;
     }
 
-
-    /**
-    * Save the tag, which will invalidate any future signatures from the same tag
-    */
-    function TagAdd (Data storage self, uint256 tag_x)
-        internal
-    {
+    /*
+     * Save the tag, which will invalidate any future signatures from the same tag
+    **/
+    function tagAdd(Data storage self, uint256 tag_x) internal {
         self.tags.push(tag_x);
     }
 
-
-    /**
-    * Generates an ordered hash segment for each public key in the ring
-    *
-    *   a ← g^t + y^c
-    *   b ← h^t + τ^c
-    *
-    * Where:
-    *
-    *   - y is a pubkey in R
-    *   - h is the root hash
-    *   - τ is the public key tag (unique per message)
-    *   - c is a random point
-    *
-    * Each segment is used when verifying the ring:
-    *
-    *   h, sum({c...}) = H(h, {(τ,a,b)...})
-    */
-    function _ringLink( uint256 previous_hash, uint256 cj, uint256 tj, Curve.Point tau, Curve.Point h, Curve.Point yj )
+    /*
+     * Generates an ordered hash segment for each public key in the ring
+     *
+     *   a ← g^t + y^c
+     *   b ← h^t + τ^c
+     *
+     * Where:
+     *
+     *   - y is a pubkey in R
+     *   - h is the root hash
+     *   - τ is the public key tag (unique per message)
+     *   - c is a random point
+     *
+     * Each segment is used when verifying the ring:
+     *
+     *   h, sum({c...}) = H(h, {(τ,a,b)...})
+    **/
+    function ringLink(uint256 previous_hash, uint256 cj, uint256 tj, Curve.Point tau, Curve.Point h, Curve.Point yj)
         internal view returns (uint256 ho)
     {
         Curve.Point memory yc = yj.ScalarMult(cj);
@@ -245,18 +217,18 @@ library LinkableRing
     /**
     * Verify whether or not a Ring Signature is valid
     *
-    * Must call TagAdd(tag_x) after a valid signature, if an existing
+    * Must call tagAdd(tag_x) after a valid signature, if an existing
     * tag exists the signature is invalidated to prevent double-spend
     */
-    function SignatureValid (Data storage self, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
+    function isSignatureValid(Data storage self, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
         internal view returns (bool)
     {
         // Ring must be full before signatures can be accepted
-        require( IsFull(self) );
+        require(isFull(self));
 
         // If tag exists, the signature is no longer valid
         // Remember, the tag must be saved to the ring afterwards
-        require( ! TagExists(self, tag_x) );
+        require(!tagExists(self, tag_x));
 
         // h ← H(h, τ)
         uint256 hashout = uint256(sha256(self.hash.X, tag_x, tag_y));
@@ -267,7 +239,7 @@ library LinkableRing
             // sum({c...})
             uint256 cj = ctlist[2*i] % Curve.GenOrder();
             uint256 tj = ctlist[2*i+1] % Curve.GenOrder();
-            hashout = _ringLink(hashout, cj, tj, Curve.Point(tag_x, tag_y), self.hash, self.pubkeys[i]);
+            hashout = ringLink(hashout, cj, tj, Curve.Point(tag_x, tag_y), self.hash, self.pubkeys[i]);
             csum = addmod(csum, cj, Curve.GenOrder());
         }
 

--- a/contracts/LinkableRing.sol
+++ b/contracts/LinkableRing.sol
@@ -45,7 +45,7 @@ import {bn256g1 as Curve} from './bn256g1.sol';
  *   h = H(guid...)
  *   for y in R
  *       h = H(h, y)
- *   m = HashToPoint(h)
+ *   m = hashToPoint(h)
  *
  *
  * Verify Signature (σ):
@@ -160,7 +160,7 @@ library LinkableRing {
         require(!pubExists(self, pub_x));
 
         Curve.Point memory pub = Curve.Point(pub_x, pub_y);
-        require(pub.IsOnCurve());
+        require(pub.isOnCurve());
 
         // Fill Ring with Public Keys
         //  R = {h ← H(h, y)}
@@ -169,7 +169,7 @@ library LinkableRing {
 
         if(isFull(self)) {
             // h ← H(h, m)
-            self.hash = Curve.HashToPoint(bytes32(self.hash.X));
+            self.hash = Curve.hashToPoint(bytes32(self.hash.X));
         }
 
         return true;
@@ -202,17 +202,16 @@ library LinkableRing {
     function ringLink(uint256 previous_hash, uint256 cj, uint256 tj, Curve.Point tau, Curve.Point h, Curve.Point yj)
         internal view returns (uint256 ho)
     {
-        Curve.Point memory yc = yj.ScalarMult(cj);
+        Curve.Point memory yc = yj.scalarMult(cj);
 
         // a ← g^t + y^c
-        Curve.Point memory a = Curve.ScalarBaseMult(tj).PointAdd(yc);
+        Curve.Point memory a = Curve.scalarBaseMult(tj).pointAdd(yc);
 
         // b ← h^t + τ^c
-        Curve.Point memory b = h.ScalarMult(tj).PointAdd(tau.ScalarMult(cj));
+        Curve.Point memory b = h.scalarMult(tj).pointAdd(tau.scalarMult(cj));
 
         return uint256(sha256(previous_hash, a.X, a.Y, b.X, b.Y));
     }
-
 
     /**
     * Verify whether or not a Ring Signature is valid
@@ -237,13 +236,13 @@ library LinkableRing {
         for (uint i = 0; i < self.pubkeys.length; i++) {
             // h ← H(h, a, b)
             // sum({c...})
-            uint256 cj = ctlist[2*i] % Curve.GenOrder();
-            uint256 tj = ctlist[2*i+1] % Curve.GenOrder();
+            uint256 cj = ctlist[2*i] % Curve.genOrder();
+            uint256 tj = ctlist[2*i+1] % Curve.genOrder();
             hashout = ringLink(hashout, cj, tj, Curve.Point(tag_x, tag_y), self.hash, self.pubkeys[i]);
-            csum = addmod(csum, cj, Curve.GenOrder());
+            csum = addmod(csum, cj, Curve.genOrder());
         }
 
-        hashout %= Curve.GenOrder();
+        hashout %= Curve.genOrder();
         return hashout == csum;
     }
 }

--- a/contracts/LinkableRing_tests.sol
+++ b/contracts/LinkableRing_tests.sol
@@ -6,85 +6,32 @@ pragma solidity ^0.4.19;
 
 import './LinkableRing.sol';
 
-contract LinkableRing_tests
-{
+contract LinkableRing_tests {
 	using LinkableRing for LinkableRing.Data;
 
 	LinkableRing.Data internal m_ring;
 
-	function LinkableRing_tests()
-        public
-    {
-        // Nothing ...
+	function LinkableRing_tests() public {
+        // Nothing
     }
 
-	function testInit ()
-		public returns (bool)
-	{
+	function testInit() public returns (bool) {
 		delete m_ring;
 
-		require( ! m_ring.IsInitialized() );
-		require( m_ring.IsDead() );
+		require(!m_ring.isInitialized());
+		require(m_ring.isDead());
 
-		_initTestRing();
+		initTestRing();
 
-		require( ! m_ring.IsFull() );
-
-		require( ! m_ring.IsDead() );
+		require(!m_ring.isFull());
+		require(!m_ring.isDead());
 
 		return true;
 	}
 
-	function _initTestRing ()
-		internal
-	{
-		delete m_ring;
-
-		var guid = sha256("1");
-		var ok = m_ring.Initialize(guid);
-		require( ok == true );
-		require( m_ring.IsInitialized() );
-		require( ! m_ring.IsFull() );
-	}
-
-	function _fillTestRing ()
-		internal
-	{
-		var ok = m_ring.AddParticipant( 15201544523224716611047554162655318369326098920760992806294282873621188361302, 8049887880302834643867918893986801628784209472486881120173132635179564996750 );
-		require( ok == true );
-		require( ! m_ring.IsFull() );
-
-		ok = m_ring.AddParticipant(2864146953215387991650307853187221646929890249230753473970630963555211270830, 19974888627227247767725306386952207830369770978312010830473870330715216459888 );
-		require( ok == true );
-
-		ok = m_ring.AddParticipant(11802586219790549114106218615216140214135730687869911031682317746534851646642, 18469118937248172961432772506316070842797392576874035050327233601294937134214);
-		require( ok == true );
-
-		ok = m_ring.AddParticipant(14750767202794174494069895486860808993207681341774320026808054547344054421581, 12924920412071921826297345645283965810489658634968309881653899964121243502566 );
-		require( ok == true );
-	}
-
-	function testParticipate ()
-		public returns (bool)
-	{
-		_initTestRing();
-		_fillTestRing();
-
-		var ok = m_ring.PubExists(15201544523224716611047554162655318369326098920760992806294282873621188361302);
-		require( ok == true );
-		require( m_ring.IsFull() );
-
-		require( m_ring.Message() == 0x291a6780850827fcd8621d0e5471343831109bc14142ec101527b048bb3d1794 );
-
-		return true;
-	}
-
-	function testVerify ()
-		public returns (bool)
-	{
-		_initTestRing();
-
-		_fillTestRing();
+	function testVerify() public returns (bool) {
+		initTestRing();
+		fillTestRing();
 
         uint256[] memory ctlist = new uint256[](8);
         ctlist[0] = 20853301309224204140850907483145190973044613001758378871848115918385899219387;
@@ -96,9 +43,46 @@ contract LinkableRing_tests
         ctlist[6] = 446022580115833093457380747787879591969245085567346575340759689027920458706;
         ctlist[7] = 16400172916399253914651469367823034567665816937929536474245909361083746809541;
 
-        var ok = m_ring.SignatureValid(13495246100508828436129396215696389042103917384015723197132056291949822869447, 17179563752757494496597752941318743229705747077314286085295431297834666711491, ctlist);
+        var ok = m_ring.isSignatureValid(13495246100508828436129396215696389042103917384015723197132056291949822869447, 17179563752757494496597752941318743229705747077314286085295431297834666711491, ctlist);
         require( ok );
 
 		return ok;
+	}
+
+	function testParticipate() public returns (bool) {
+		initTestRing();
+		fillTestRing();
+
+		var ok = m_ring.pubExists(15201544523224716611047554162655318369326098920760992806294282873621188361302);
+		require(ok == true);
+		require(m_ring.isFull());
+		require(m_ring.message() == 0x291a6780850827fcd8621d0e5471343831109bc14142ec101527b048bb3d1794);
+
+		return true;
+	}
+
+    function initTestRing() internal {
+		delete m_ring;
+
+		var guid = sha256("1");
+		var ok = m_ring.initialize(guid);
+		require(ok == true);
+		require(m_ring.isInitialized());
+		require(!m_ring.isFull());
+	}
+
+    function fillTestRing() internal {
+		var ok = m_ring.addParticipant( 15201544523224716611047554162655318369326098920760992806294282873621188361302, 8049887880302834643867918893986801628784209472486881120173132635179564996750 );
+		require(ok == true);
+		require(!m_ring.isFull());
+
+		ok = m_ring.addParticipant(2864146953215387991650307853187221646929890249230753473970630963555211270830, 19974888627227247767725306386952207830369770978312010830473870330715216459888 );
+		require(ok == true);
+
+		ok = m_ring.addParticipant(11802586219790549114106218615216140214135730687869911031682317746534851646642, 18469118937248172961432772506316070842797392576874035050327233601294937134214);
+		require(ok == true);
+
+		ok = m_ring.addParticipant(14750767202794174494069895486860808993207681341774320026808054547344054421581, 12924920412071921826297345645283965810489658634968309881653899964121243502566 );
+		require(ok == true);
 	}
 }

--- a/contracts/Mixer.sol
+++ b/contracts/Mixer.sol
@@ -103,7 +103,7 @@ contract Mixer is ERC223ReceivingContract {
     /*
      * Given a GUID of a full Ring, return the Message to sign
     **/
-    function getMessage (bytes32 ring_guid)
+    function message(bytes32 ring_guid)
         public view returns (bytes32)
     {
         Data storage entry = m_rings[ring_guid];
@@ -112,14 +112,14 @@ contract Mixer is ERC223ReceivingContract {
         // Entry is empty, non-existant ring
         require(0 != entry.denomination);
 
-        return ring.Message();
+        return ring.message();
     }
 
     /*
      * Deposit a specific denomination of Ethers which can only be withdrawn
      * by providing a ring signature by one of the public keys.
     **/
-    function depositEther (address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
+    function depositEther(address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
         public payable returns (bytes32)
     {
         require(token == 0);
@@ -133,7 +133,7 @@ contract Mixer is ERC223ReceivingContract {
      * Deposit a specific denomination of ERC20 compatible tokens which can only be withdrawn
      * by providing a ring signature by one of the public keys.
     **/
-    function depositERC20Compatible (address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
+    function depositERC20Compatible(address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
         public returns (bytes32)
     {
         uint256 codeLength;
@@ -156,7 +156,7 @@ contract Mixer is ERC223ReceivingContract {
      * must provide a Signature which has a unique Tag. Each Tag can only be used
      * once.
     **/
-    function withdrawEther (bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
+    function withdrawEther(bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
         public returns (bool)
     {
         Data memory entry = withdrawLogic(ring_id, tag_x, tag_y, ctlist);
@@ -170,7 +170,7 @@ contract Mixer is ERC223ReceivingContract {
      * must provide a Signature which has a unique Tag. Each Tag can only be used
      * once.
     **/
-    function withdrawERC20Compatible (bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
+    function withdrawERC20Compatible(bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
         public returns (bool)
     {
         Data memory entry = withdrawLogic(ring_id, tag_x, tag_y, ctlist);
@@ -187,7 +187,7 @@ contract Mixer is ERC223ReceivingContract {
      * this will create a new unfilled ring if none exists. When the ring
      * is full the 'filling' ring will be deleted.
     **/
-    function lookupFillingRing (address token, uint256 denomination)
+    function lookupFillingRing(address token, uint256 denomination)
         internal returns (bytes32, Data storage)
     {
         // The filling ID allows quick lookup for the same Token and Denomination
@@ -203,7 +203,7 @@ contract Mixer is ERC223ReceivingContract {
 
         // Entry must be initialized only once
         require(0 == entry.denomination);
-        require(entry.ring.Initialize(ring_guid));
+        require(entry.ring.initialize(ring_guid));
 
         entry.guid = ring_guid;
         entry.token = token;
@@ -230,7 +230,7 @@ contract Mixer is ERC223ReceivingContract {
 
         LinkableRing.Data storage ring = entry.ring;
 
-        require(ring.AddParticipant(pub_x, pub_y));
+        require(ring.addParticipant(pub_x, pub_y));
 
         // Associate Public X point with Ring GUID
         // This allows the ring to be recovered with the public key
@@ -241,9 +241,9 @@ contract Mixer is ERC223ReceivingContract {
 
         // When full, emit the GUID as the Ring Message
         // Participants need to sign this Message to Withdraw
-        if(ring.IsFull()) {
+        if(ring.isFull()) {
             delete m_filling[filling_id];
-            LogMixerReady(ring_guid, ring.Message());
+            LogMixerReady(ring_guid, ring.message());
         }
 
         return ring_guid;
@@ -258,12 +258,12 @@ contract Mixer is ERC223ReceivingContract {
         // Entry is empty, non-existant ring
         require(0 != entry.denomination);
 
-        require(ring.IsFull());
+        require(ring.isFull());
 
-        require(ring.SignatureValid(tag_x, tag_y, ctlist));
+        require(ring.isSignatureValid(tag_x, tag_y, ctlist));
 
         // Tag must be added before withdraw
-        ring.TagAdd(tag_x);
+        ring.tagAdd(tag_x);
 
         LogMixerWithdraw(ring_id, tag_x, entry.token, entry.denomination);
 
@@ -275,7 +275,7 @@ contract Mixer is ERC223ReceivingContract {
 
         // When Tags.length == Pubkeys.length, the ring is dead
         // Remove mappings and delete ring
-        if(ring.IsDead()) {
+        if(ring.isDead()) {
             for(uint i = 0; i < ring.pubkeys.length; i++) {
                 delete m_pubx_to_ring[ring.pubkeys[i].X];
             }

--- a/contracts/Mixer.sol
+++ b/contracts/Mixer.sol
@@ -193,8 +193,9 @@ contract Mixer is ERC223ReceivingContract {
         // The filling ID allows quick lookup for the same Token and Denomination
         var filling_id = sha256(token, denomination);
         var ring_guid = m_filling[filling_id];
-        if(ring_guid != 0)
+        if(ring_guid != 0) {
             return (filling_id, m_rings[ring_guid]);
+        }
 
         // The GUID is unique per Mixer instance, Nonce, Token and Denomination
         ring_guid = sha256(address(this), m_ring_ctr, filling_id);

--- a/contracts/Mixer.sol
+++ b/contracts/Mixer.sol
@@ -30,23 +30,23 @@ contract ERC20Compatible {
  * can then be monitored using the following events which demarcate
  * the state transitions:
  *
- * MixerDeposit
- *   For each Deposit a MixerDeposit message is emitted, this includes
+ * LogMixerDeposit
+ *   For each Deposit a LogMixerDeposit message is emitted, this includes
  *   the Ring GUID, the X point of the Stealth Address, and the Token
  *   address and Denomination.
  *
- * MixerReady
- *   When a Ring is full and withdrawals can be made a RingReady
+ * LogMixerReady
+ *   When a Ring is full and withdrawals can be made a LogMixerReady
  *   event is emitted, this includes the Ring GUID and the Message
  *   which must be signed to Withdraw.
  *
- * MixerWithdraw
- *   For each Withdraw a MixerWithdraw message is emitted, this includes
+ * LogMixerWithdraw
+ *   For each Withdraw a LogMixerWithdraw message is emitted, this includes
  *   the Token, Denomination, Ring GUID and Tag of the withdrawer.
  *
- * MixerDead
+ * LogMixerDead
  *   When all participants have withdrawn their tokens from a Ring the
- *   MixerDead event is emitted, this specifies the Ring GUID.
+ *   LogMixerDead event is emitted, this specifies the Ring GUID.
 **/
 
 contract Mixer is ERC223ReceivingContract {
@@ -61,64 +61,139 @@ contract Mixer is ERC223ReceivingContract {
 
     mapping(bytes32 => Data) internal m_rings;
 
-    /** With a public key, lookup which ring it belongs to */
+    // With a public key, lookup which ring it belongs to
     mapping(uint256 => bytes32) internal m_pubx_to_ring;
 
-    /** Rings which aren't full yet, H(token,denom) -> ring_id */
+    // Rings which aren't full yet, H(token,denom) -> ring_id
     mapping(bytes32 => bytes32) internal m_filling;
 
-    /** Nonce used to generate Ring Messages */
+    // Nonce used to generate Ring Messages
     uint256 internal m_ring_ctr;
 
-    /**
-    * Token has been deposited into a Mixer Ring
-    */
-    event MixerDeposit(
+    // Token has been deposited into a Mixer Ring
+    event LogMixerDeposit(
         bytes32 indexed ring_id,
         uint256 indexed pub_x,
         address token,
         uint256 value
     );
 
-    /**
-    * Token has been withdraw from a Mixer Ring
-    */
-    event MixerWithdraw(
+    // Token has been withdraw from a Mixer Ring
+    event LogMixerWithdraw(
         bytes32 indexed ring_id,
         uint256 tag_x,
         address token,
         uint256 value
     );
 
-    /**
-     * A Mixer Ring is Full, Tokens can now be withdrawn from it
-     */
-    event MixerReady( bytes32 indexed ring_id, bytes32 message );
+    // A Mixer Ring is Full, Tokens can now be withdrawn from it
+    event LogMixerReady(bytes32 indexed ring_id, bytes32 message);
 
-    /**
-    * A Mixer Ring has been fully with withdrawn, the Ring is dead.
-    */
-    event MixerDead( bytes32 indexed ring_id );
+    // A Mixer Ring has been fully withdrawn, the Ring is dead
+    event LogMixerDead(bytes32 indexed ring_id);
 
-
-    function Mixer()
-        public
-    {
-        // Nothing ...
+    function Mixer() public {
+        // Nothing
     }
 
-    /**
-    * Lookup an unfilled/filling ring for a given token and denomination,
-    * this will create a new unfilled ring if none exists. When the ring
-    * is full the 'filling' ring will be deleted.
-    */
+    function () public {
+        revert();
+    }
+
+    /*
+     * Given a GUID of a full Ring, return the Message to sign
+    **/
+    function getMessage (bytes32 ring_guid)
+        public view returns (bytes32)
+    {
+        Data storage entry = m_rings[ring_guid];
+        LinkableRing.Data storage ring = entry.ring;
+
+        // Entry is empty, non-existant ring
+        require(0 != entry.denomination);
+
+        return ring.Message();
+    }
+
+    /*
+     * Deposit a specific denomination of Ethers which can only be withdrawn
+     * by providing a ring signature by one of the public keys.
+    **/
+    function depositEther (address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
+        public payable returns (bytes32)
+    {
+        require(token == 0);
+        require(denomination == msg.value);
+
+        bytes32 ring_guid = depositLogic(token, denomination, pub_x, pub_y);
+        return ring_guid;
+    }
+
+    /*
+     * Deposit a specific denomination of ERC20 compatible tokens which can only be withdrawn
+     * by providing a ring signature by one of the public keys.
+    **/
+    function depositERC20Compatible (address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
+        public returns (bytes32)
+    {
+        uint256 codeLength;
+        assembly {
+            codeLength := extcodesize(token)
+        }
+
+        require(token != 0 && codeLength > 0);
+        bytes32 ring_guid = depositLogic(token, denomination, pub_x, pub_y);
+
+        // Call to an untrusted external contract done at the end of the function for security measures
+        ERC20Compatible untrustedErc20Token = ERC20Compatible(token);
+        untrustedErc20Token.transferFrom(msg.sender, this, denomination);
+
+        return ring_guid;
+    }
+
+    /*
+     * To Withdraw a denomination of Ethers from the Ring, one of the Public Keys
+     * must provide a Signature which has a unique Tag. Each Tag can only be used
+     * once.
+    **/
+    function withdrawEther (bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
+        public returns (bool)
+    {
+        Data memory entry = withdrawLogic(ring_id, tag_x, tag_y, ctlist);
+        msg.sender.transfer(entry.denomination);
+
+        return true;
+    }
+
+    /*
+     * To Withdraw a denomination of ERC20 compatible tokens from the Ring, one of the Public Keys
+     * must provide a Signature which has a unique Tag. Each Tag can only be used
+     * once.
+    **/
+    function withdrawERC20Compatible (bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
+        public returns (bool)
+    {
+        Data memory entry = withdrawLogic(ring_id, tag_x, tag_y, ctlist);
+
+        // Call to an untrusted external contract done at the end of the function for security measures
+        ERC20Compatible untrustedErc20Token = ERC20Compatible(entry.token);
+        untrustedErc20Token.transfer(msg.sender, entry.denomination);
+
+        return true;
+    }
+
+    /*
+     * Lookup an unfilled/filling ring for a given token and denomination,
+     * this will create a new unfilled ring if none exists. When the ring
+     * is full the 'filling' ring will be deleted.
+    **/
     function lookupFillingRing (address token, uint256 denomination)
         internal returns (bytes32, Data storage)
     {
         // The filling ID allows quick lookup for the same Token and Denomination
         var filling_id = sha256(token, denomination);
         var ring_guid = m_filling[filling_id];
-        if( ring_guid != 0 )
+        if(ring_guid != 0)
             return (filling_id, m_rings[ring_guid]);
 
         // The GUID is unique per Mixer instance, Nonce, Token and Denomination
@@ -127,8 +202,8 @@ contract Mixer is ERC223ReceivingContract {
         Data storage entry = m_rings[ring_guid];
 
         // Entry must be initialized only once
-        require( 0 == entry.denomination );
-        require( entry.ring.Initialize(ring_guid) );
+        require(0 == entry.denomination);
+        require(entry.ring.Initialize(ring_guid));
 
         entry.guid = ring_guid;
         entry.token = token;
@@ -140,96 +215,14 @@ contract Mixer is ERC223ReceivingContract {
         return (filling_id, entry);
     }
 
-    /**
-    * Given a GUID of a full Ring, return the Message to sign
-    */
-    function Message (bytes32 ring_guid)
-        public view returns (bytes32)
-    {
-        Data storage entry = m_rings[ring_guid];
-        LinkableRing.Data storage ring = entry.ring;
-
-        // Entry is empty, non-existant ring
-        require( 0 != entry.denomination );
-
-        return ring.Message();
-    }
-
-    /**
-    * Deposit a specific denomination of ethers which can only be withdrawn
-    * by providing a ring signature by one of the public keys.
-    */
-    function DepositEther (address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
-        public payable returns (bytes32)
-    {
-        require( token == 0);
-        require( denomination == msg.value );
-
-        bytes32 ring_guid = DepositLogic(token, denomination, pub_x, pub_y);
-        return ring_guid;
-    }
-
-    /**
-    * Deposit a specific denomination of ERC20 compatible tokens which can only be withdrawn
-    * by providing a ring signature by one of the public keys.
-    */
-    function DepositERC20Compatible (address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
-        public returns (bytes32)
-    {
-        uint256 codeLength;
-        assembly {
-            codeLength := extcodesize(token)
-        }
-
-        require( token != 0 && codeLength > 0);
-        bytes32 ring_guid = DepositLogic(token, denomination, pub_x, pub_y);
-
-        // Call to an untrusted external contract
-        ERC20Compatible UntrustedErc20Token = ERC20Compatible(token);
-        UntrustedErc20Token.transferFrom(msg.sender, this, denomination);
-
-        return ring_guid;
-    }
-
-    /**
-    * To Withdraw a denomination of ethers from the Ring, one of the Public Keys
-    * must provide a Signature which has a unique Tag. Each Tag can only be used
-    * once.
-    */
-    function WithdrawEther (bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
-        public returns (bool)
-    {
-        Data memory entry = WithdrawLogic(ring_id, tag_x, tag_y, ctlist);
-        msg.sender.transfer(entry.denomination);
-
-        return true;
-    }
-
-    /**
-    * To Withdraw a denomination of ERC20 compatible tokens from the Ring, one of the Public Keys
-    * must provide a Signature which has a unique Tag. Each Tag can only be used
-    * once.
-    */
-    function WithdrawERC20Compatible (bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
-        public returns (bool)
-    {
-        Data memory entry = WithdrawLogic(ring_id, tag_x, tag_y, ctlist);
-
-        // Call to an untrusted external contract done at the end of the function for security measures
-        ERC20Compatible UntrustedErc20Token = ERC20Compatible(entry.token);
-        UntrustedErc20Token.transfer(msg.sender, entry.denomination);
-
-        return true;
-    }
-
-    function DepositLogic(address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
+    function depositLogic(address token, uint256 denomination, uint256 pub_x, uint256 pub_y)
         internal returns (bytes32)
     {
         // Denomination must be positive power of 2, e.g. only 1 bit set
-        require( denomination != 0 && 0 == (denomination & (denomination - 1)) );
+        require(denomination != 0 && 0 == (denomination & (denomination - 1)));
 
         // Public key can only exist in one ring at a time
-        require( 0 == uint256(m_pubx_to_ring[pub_x]) );
+        require(0 == uint256(m_pubx_to_ring[pub_x]));
 
         bytes32 filling_id;
         Data storage entry;
@@ -237,42 +230,42 @@ contract Mixer is ERC223ReceivingContract {
 
         LinkableRing.Data storage ring = entry.ring;
 
-        require( ring.AddParticipant(pub_x, pub_y) );
+        require(ring.AddParticipant(pub_x, pub_y));
 
         // Associate Public X point with Ring GUID
         // This allows the ring to be recovered with the public key
         // Without having to monitor/replay the RingDeposit events
         var ring_guid = entry.guid;
         m_pubx_to_ring[pub_x] = ring_guid;
-        MixerDeposit(ring_guid, pub_x, token, denomination);
+        LogMixerDeposit(ring_guid, pub_x, token, denomination);
 
         // When full, emit the GUID as the Ring Message
         // Participants need to sign this Message to Withdraw
-        if( ring.IsFull() ) {
+        if(ring.IsFull()) {
             delete m_filling[filling_id];
-            MixerReady(ring_guid, ring.Message());
+            LogMixerReady(ring_guid, ring.Message());
         }
 
         return ring_guid;
     }
 
-    function WithdrawLogic(bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
+    function withdrawLogic(bytes32 ring_id, uint256 tag_x, uint256 tag_y, uint256[] ctlist)
         internal returns (Data)
     {
         Data storage entry = m_rings[ring_id];
         LinkableRing.Data storage ring = entry.ring;
 
         // Entry is empty, non-existant ring
-        require( 0 != entry.denomination );
+        require(0 != entry.denomination);
 
-        require( ring.IsFull() );
+        require(ring.IsFull());
 
-        require( ring.SignatureValid(tag_x, tag_y, ctlist) );
+        require(ring.SignatureValid(tag_x, tag_y, ctlist));
 
         // Tag must be added before withdraw
         ring.TagAdd(tag_x);
 
-        MixerWithdraw(ring_id, tag_x, entry.token, entry.denomination);
+        LogMixerWithdraw(ring_id, tag_x, entry.token, entry.denomination);
 
         // We want to return a copy of the entry in order to be able to access
         // the token and denomination fields of this object.
@@ -282,18 +275,14 @@ contract Mixer is ERC223ReceivingContract {
 
         // When Tags.length == Pubkeys.length, the ring is dead
         // Remove mappings and delete ring
-        if( ring.IsDead() ) {
-            for( uint i = 0; i < ring.pubkeys.length; i++ ) {
+        if(ring.IsDead()) {
+            for(uint i = 0; i < ring.pubkeys.length; i++) {
                 delete m_pubx_to_ring[ring.pubkeys[i].X];
             }
             delete m_rings[ring_id];
-            MixerDead(ring_id);
+            LogMixerDead(ring_id);
         }
 
         return entrySaved;
-    }
-
-    function () public {
-        revert();
     }
 }

--- a/contracts/bn256g1.sol
+++ b/contracts/bn256g1.sol
@@ -4,54 +4,54 @@
 
 pragma solidity ^0.4.19;
 
-/**
-* This module wraps the alt_bn128 G1 Elliptic Curve functions into
-* a helpful and consistent library which provides familiar function
-* names and usage to Elliptic Curve libraries in other languages.
-*
-* This curve is described in the IACR paper 2010/429
-*
-*  - https://eprint.iacr.org/2010/429
-*    A Family of Implementation-Friendly BN Elliptic Curves
-*
-* Specified in the following EIPs:
-*
-*  - https://github.com/ethereum/EIPs/pull/213
-*  - https://github.com/ethereum/EIPs/pull/212
-*
-* The 𝔾1 curve is of the form:
-*
-*   (E_b : y^2 = x^3 + b) over 𝔽_p
-*
-* Where:
-*
-*   p ≡ 3 (mod 4)
-*   b = 3
-*   sqrt(a) = a^((p+1)/4)
-*
-* The primes `p` (field modulus) and `n` (order) are given by:
-*
-*   p = p(u) = 36u^4 + 36u^3 + 24u^2 + 6u + 1
-*   n = n(u) = 36u^4 + 36u^3 + 18u^2 + 6u + 1
-*
-* The BN field 𝔽_p contains a primitive cube root of unity, this makes
-* it very easy to implement using integer operations on a computer.
-*
-* For more details, refer to the IACR paper, we have tried to ensure
-* that the variable names and comments throughout this library make it
-* easier for cryptographers, mathematicians and programmers alike to
-* use the same terminology across multiple domains without confusion.
-*
-* The parameters used by the ALT_BN128 curve implemented in Ethereum are:
-*
-*   p = 21888242871839275222246405745257275088696311157297823662689037894645226208583
-*   n = 21888242871839275222246405745257275088548364400416034343698204186575808495617
-*   b = 3
-*   u = 4965661367192848881
-*   a = 5472060717959818805561601436314318772174077789324455915672259473661306552146
-*/
-library bn256g1
-{
+/*
+ * This module wraps the alt_bn128 G1 Elliptic Curve functions into
+ * a helpful and consistent library which provides familiar function
+ * names and usage to Elliptic Curve libraries in other languages.
+ *
+ * This curve is described in the IACR paper 2010/429
+ *
+ *  - https://eprint.iacr.org/2010/429
+ *    A Family of Implementation-Friendly BN Elliptic Curves
+ *
+ * Specified in the following EIPs:
+ *
+ *  - https://github.com/ethereum/EIPs/pull/213
+ *  - https://github.com/ethereum/EIPs/pull/212
+ *
+ * The 𝔾1 curve is of the form:
+ *
+ *   (E_b : y^2 = x^3 + b) over 𝔽_p
+ *
+ * Where:
+ *
+ *   p ≡ 3 (mod 4)
+ *   b = 3
+ *   sqrt(a) = a^((p+1)/4)
+ *
+ * The primes `p` (field modulus) and `n` (order) are given by:
+ *
+ *   p = p(u) = 36u^4 + 36u^3 + 24u^2 + 6u + 1
+ *   n = n(u) = 36u^4 + 36u^3 + 18u^2 + 6u + 1
+ *
+ * The BN field 𝔽_p contains a primitive cube root of unity, this makes
+ * it very easy to implement using integer operations on a computer.
+ *
+ * For more details, refer to the IACR paper, we have tried to ensure
+ * that the variable names and comments throughout this library make it
+ * easier for cryptographers, mathematicians and programmers alike to
+ * use the same terminology across multiple domains without confusion.
+ *
+ * The parameters used by the ALT_BN128 curve implemented in Ethereum are:
+ *
+ *   p = 21888242871839275222246405745257275088696311157297823662689037894645226208583
+ *   n = 21888242871839275222246405745257275088548364400416034343698204186575808495617
+ *   b = 3
+ *   u = 4965661367192848881
+ *   a = 5472060717959818805561601436314318772174077789324455915672259473661306552146
+**/
+
+library bn256g1 {
     // p = p(u) = 36u^4 + 36u^3 + 24u^2 + 6u + 1
     uint256 internal constant FIELD_ORDER = 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47;
 
@@ -64,77 +64,62 @@ library bn256g1
     // a = (p+1) / 4
     uint256 internal constant CURVE_A = 0xc19139cb84c680a6e14116da060561765e05aa45a1c72a34f082305b61f3f52;
 
-
-    function GenOrder() internal pure returns (uint256) {
-        return GEN_ORDER;
-    }
-
-
-    function FieldOrder() internal pure returns (uint256) {
-        return FIELD_ORDER;
-    }
-
-
     struct Point {
         uint256 X;
         uint256 Y;
     }
 
+    function genOrder() internal pure returns (uint256) {
+        return GEN_ORDER;
+    }
 
-    function Infinity ()
-        internal pure returns (Point)
-    {
+    function fieldOrder() internal pure returns (uint256) {
+        return FIELD_ORDER;
+    }
+
+    function infinity() internal pure returns (Point) {
         return Point(0, 0);
     }
 
-
-    function Generator ()
-        internal pure returns (Point)
-    {
+    function generator() internal pure returns (Point) {
         return Point(1, 2);
     }
 
-
-    function Equal(Point a, Point b)
-        internal pure returns (bool)
-    {
+    function equal(Point a, Point b) internal pure returns (bool) {
         return a.X == b.X && a.Y == b.Y;
     }
 
-
-    /// @return the negation of p, i.e. p.add(p.negate()) should be zero.
-    function Negate(Point p)
-        internal pure returns (Point)
-    {
-        if (p.X == 0 && p.Y == 0)
+    /*
+     * Return the negation of p, i.e. p.add(p.negate()) should be zero.
+    **/
+    function negate(Point p) internal pure returns (Point) {
+        if(p.X == 0 && p.Y == 0) {
             return Point(0, 0);
+        }
         // TODO: SubMod function?
         return Point(p.X, FIELD_ORDER - (p.Y % FIELD_ORDER));
     }
 
-
-    /**
-    * Using a hashed value as the initial starting X point, find the
-    * nearest (X,Y) point on the curve. The input must be hashed first.
-    *
-    * Example:
-    *
-    *   HashToPoint(sha256("hello world"))
-    *
-    * XXX: this isn't constant time!
-    *
-    * This implements the try-and-increment method of hashing a scalar
-    * into a curve point. For more information see:
-    *
-    *  - https://iacr.org/archive/crypto2009/56770300/56770300.pdf
-    *    How to Hash into Elliptic Curves
-    *
-    *  - https://www.normalesup.org/~tibouchi/papers/bnhash-scis.pdf
-    *    A Note on Hashing to BN Curves
-    */
-    function HashToPoint(bytes32 s)
-        internal view returns (Point)
-    {
+    /*
+     * Using a hashed value as the initial starting X point, find the
+     * nearest (X,Y) point on the curve. The input must be hashed first.
+     *
+     * Example:
+     *
+     *   hashToPoint(sha256("hello world"))
+     *
+     * XXX: this isn't constant time!
+     *
+     * This implements the try-and-increment method of hashing a scalar
+     * into a curve point. For more information see:
+     *
+     *  - https://iacr.org/archive/crypto2009/56770300/56770300.pdf
+     *    How to Hash into Elliptic Curves
+     *
+     *  - https://www.normalesup.org/~tibouchi/papers/bnhash-scis.pdf
+     *    A Note on Hashing to BN Curves
+    **/
+    function hashToPoint(bytes32 s) internal view returns (Point) {
         uint256 beta = 0;
         uint256 y = 0;
 
@@ -142,10 +127,10 @@ library bn256g1
         uint256 x = uint256(s) % GEN_ORDER;
 
         while( true ) {
-            (beta, y) = FindYforX(x);
+            (beta, y) = findYforX(x);
 
             // y^2 == beta
-            if( beta == mulmod(y, y, FIELD_ORDER) ) {
+            if(beta == mulmod(y, y, FIELD_ORDER)) {
                 return Point(x, y);
             }
 
@@ -153,17 +138,14 @@ library bn256g1
         }
     }
 
-
-    /**
-    * Given X, find Y
-    *
-    *   where y = sqrt(x^3 + b)
-    *
-    * Returns: (x^3 + b), y
-    */
-    function FindYforX(uint256 x)
-        internal view returns (uint256, uint256)
-    {
+    /*
+     * Given X, find Y
+     *
+     *   where y = sqrt(x^3 + b)
+     *
+     * Returns: (x^3 + b), y
+    **/
+    function findYforX(uint256 x) internal view returns (uint256, uint256) {
         // beta = (x^3 + b) % p
         uint256 beta = addmod(mulmod(mulmod(x, x, FIELD_ORDER), x, FIELD_ORDER), CURVE_B, FIELD_ORDER);
 
@@ -174,42 +156,32 @@ library bn256g1
         return (beta, y);
     }
 
-
-    function IsInfinity(Point p)
-        internal pure returns (bool)
-    {
+    function isInfinity(Point p) internal pure returns (bool) {
         return p.X == 0 && p.Y == 0;
     }
 
-
-    /**
-    * Verify if the X and Y coordinates represent a valid Point on the Curve
-    *
-    * Where the G1 curve is: x^2 = x^3 + b
-    */
-    function IsOnCurve(Point p)
-        internal pure returns (bool)
-    {
+    /*
+     * Verify if the X and Y coordinates represent a valid Point on the Curve
+     *
+     * Where the G1 curve is: x^2 = x^3 + b
+    **/
+    function isOnCurve(Point p) internal pure returns (bool) {
         uint256 p_squared = mulmod(p.X, p.X, FIELD_ORDER);
         uint256 p_cubed = mulmod(p_squared, p.X, FIELD_ORDER);
         return addmod(p_cubed, CURVE_B, FIELD_ORDER) == mulmod(p.Y, p.Y, FIELD_ORDER);
     }
 
-
-    /**
-    * Multiply the curve generator by a scalar
-    */
-    function ScalarBaseMult(uint256 x)
-        internal view returns (Point r)
-    {
-        return ScalarMult(Generator(), x);
+    /*
+     * Multiply the curve generator by a scalar
+    **/
+    function scalarBaseMult(uint256 x) internal view returns (Point r) {
+        return scalarMult(generator(), x);
     }
 
-
-    // sum of two points
-    function PointAdd(Point p1, Point p2)
-        internal view returns (Point r)
-    {
+    /*
+     * Sum of two points
+    **/
+    function pointAdd(Point p1, Point p2) internal view returns (Point r) {
         uint256[4] memory input;
         input[0] = p1.X;
         input[1] = p1.Y;
@@ -224,11 +196,10 @@ library bn256g1
         require(success);
     }
 
-
-    // Multiply point by a scalar
-    function ScalarMult(Point p, uint256 s)
-        internal view returns (Point r)
-    {
+    /*
+     * Multiply point by a scalar
+    **/
+    function scalarMult(Point p, uint256 s) internal view returns (Point r) {
         uint256[3] memory input;
         input[0] = p.X;
         input[1] = p.Y;
@@ -239,11 +210,10 @@ library bn256g1
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid }
         }
-        require (success);
+        require(success);
     }
 
-
-    function expMod(uint256 _base, uint256 _exponent, uint256 _modulus)
+    function expMod(uint256 base, uint256 exponent, uint256 modulus)
         internal view returns (uint256 retval)
     {
         bool success;
@@ -252,9 +222,9 @@ library bn256g1
         input[0] = 0x20;        // baseLen = new(big.Int).SetBytes(getData(input, 0, 32))
         input[1] = 0x20;        // expLen  = new(big.Int).SetBytes(getData(input, 32, 32))
         input[2] = 0x20;        // modLen  = new(big.Int).SetBytes(getData(input, 64, 32))
-        input[3] = _base;
-        input[4] = _exponent;
-        input[5] = _modulus;
+        input[3] = base;
+        input[4] = exponent;
+        input[5] = modulus;
         assembly {
             success := staticcall(sub(gas, 2000), 5, input, 0xc0, output, 0x20)
             // Use "invalid" to make gas estimation work

--- a/contracts/bn256g1_tests.sol
+++ b/contracts/bn256g1_tests.sol
@@ -6,92 +6,81 @@ pragma solidity ^0.4.19;
 
 import './bn256g1.sol';
 
-contract bn256g1_tests
-{
+contract bn256g1_tests {
 	using bn256g1 for bn256g1.Point;
 
-	function testOnCurve()
-		public view returns (bool)
-	{
-		var g = bn256g1.Generator();
-		require( g.IsOnCurve() );
+	function testIsOnCurve() public view returns (bool) {
+		var g = bn256g1.generator();
 
-		var x = g.ScalarMult(uint256(sha256("1")));
-		require( x.IsOnCurve() );
+		require(g.isOnCurve());
 
-		require( x.X == 0x28af4f278e71322e8e155dce4641e18ddb8ce0d4cee01d8ea9d052cf564e9029 );
+		var x = g.scalarMult(uint256(sha256("1")));
 
-		require( x.Y == 0x71c77766b8f58944c18c66df8edac3c4ff5ab15e246e5f7457ae4fd6adb939c );
-
-		require( ! bn256g1.ScalarBaseMult(0).IsOnCurve() );
+		require(x.isOnCurve());
+		require(x.X == 0x28af4f278e71322e8e155dce4641e18ddb8ce0d4cee01d8ea9d052cf564e9029);
+		require(x.Y == 0x71c77766b8f58944c18c66df8edac3c4ff5ab15e246e5f7457ae4fd6adb939c);
+		require(!bn256g1.scalarBaseMult(0).isOnCurve());
 
 		return true;
 	}
 
-	function testHashToPoint()
-		public view returns (bool)
-	{
-		var p = bn256g1.HashToPoint(sha256("hello world"));
-		require( p.IsOnCurve() );
+	function testHashToPoint() public view returns (bool) {
+		var p = bn256g1.hashToPoint(sha256("hello world"));
 
-		require( p.X == 18149469767584732552991861025120904666601524803017597654373315627649680264678 );
-
-		require( p.Y == 18593544354303197021588991433499968191850988132424885073381608163097237734820 );
+		require(p.isOnCurve());
+		require(p.X == 18149469767584732552991861025120904666601524803017597654373315627649680264678);
+		require(p.Y == 18593544354303197021588991433499968191850988132424885073381608163097237734820);
 
 		return true;
 	}
 
-	function testNegate()
-		public view returns (bool)
-	{
-		var g = bn256g1.Generator();
-		var x = g.PointAdd(g.Negate());
-		require( x.IsInfinity() );
+	function testNegate() public view returns (bool) {
+		var g = bn256g1.generator();
+		var x = g.pointAdd(g.negate());
+
+		require(x.isInfinity());
+
 		return true;
 	}
 
-	function testIdentity()
-		public view returns (bool)
-	{
-		require( bn256g1.ScalarBaseMult(0).IsInfinity() );
+	function testIdentity() public view returns (bool) {
+		require(bn256g1.scalarBaseMult(0).isInfinity());
+
 		return true;
 	}
 
-	function testEquality()
-		public view returns (bool)
-	{
-		var g = bn256g1.Generator();
-		var a = g.ScalarMult(9).PointAdd(g.ScalarMult(5));
-		var b = g.ScalarMult(12).PointAdd(g.ScalarMult(2));
-		require( a.Equal(b) );
+	function testEquality() public view returns (bool) {
+		var g = bn256g1.generator();
+		var a = g.scalarMult(9).pointAdd(g.scalarMult(5));
+		var b = g.scalarMult(12).pointAdd(g.scalarMult(2));
+
+		require(a.Equal(b));
+
 		return true;
 	}
 
-	function testOrder()
-		public view returns (bool)
-	{
-		var z = bn256g1.ScalarBaseMult(bn256g1.GenOrder());
-		require( z.IsInfinity() );
+	function testOrder() public view returns (bool) {
+		var z = bn256g1.scalarBaseMult(bn256g1.genOrder());
+		require(z.isInfinity());
 
-		var one = bn256g1.ScalarBaseMult(1);
-		var x = z.PointAdd(one);
-		require( x.X == one.X && x.Y == one.Y );
+		var one = bn256g1.scalarBaseMult(1);
+		var x = z.pointAdd(one);
+		require(x.X == one.X && x.Y == one.Y);
+
 		return true;
 	}
 
-	function testModExp()
-		public view returns (bool)
-	{
+	function testModExp() public view returns (bool) {
 		uint256 a;
 
 		a = bn256g1.expMod(33, 2, 100);
-		require( a == 89 );
+		require(a == 89);
 
 		a = bn256g1.expMod(50, 2, 100);
-		require( a == 0 );
+		require(a == 0);
 
 		a = bn256g1.expMod(51, 2, 100);
-		require( a == 1 );
+		require(a == 1);
 
 		return true;
 	}

--- a/contracts/bn256g1_tests.sol
+++ b/contracts/bn256g1_tests.sol
@@ -54,7 +54,7 @@ contract bn256g1_tests {
 		var a = g.scalarMult(9).pointAdd(g.scalarMult(5));
 		var b = g.scalarMult(12).pointAdd(g.scalarMult(2));
 
-		require(a.Equal(b));
+		require(a.equal(b));
 
 		return true;
 	}

--- a/test/mobius.js
+++ b/test/mobius.js
@@ -1,15 +1,13 @@
-// Copyright (c) 2016-2017 Clearmatics Technologies Ltd
+// Copyright (c) 2016-2018 Clearmatics Technologies Ltd
 
 // SPDX-License-Identifier: LGPL-3.0+
 
 const bigInt = require("big-integer");
 var JSONBigInt = require('json-bigint-string');
 
-
 const LinkableRing_tests = artifacts.require("./LinkableRing_tests.sol");
 const Mixer = artifacts.require("./Mixer.sol");
 const bn256g1_tests = artifacts.require("./bn256g1_tests.sol");
-
 
 // XXX: truffle solidity tests are a lil broken due to the 'import' bug
 // e.g. the imports in contracts/ are relative to the CWD not the source file
@@ -19,15 +17,24 @@ const testContracts = {
     LinkableRing_tests: LinkableRing_tests,
     bn256g1_tests: bn256g1_tests
 };
+
 const allSimpleTests = {
     bn256g1_tests:  [
-        "testOnCurve", "testHashToPoint", "testNegate", "testIdentity", "testEquality",
-        "testOrder", "testModExp"
+      "testIsOnCurve",
+      "testHashToPoint",
+      "testNegate",
+      "testIdentity",
+      "testEquality",
+      "testOrder",
+      "testModExp"
     ],
     LinkableRing_tests: [
-        "testInit", "testParticipate", "testVerify",
+      "testInit",
+      "testVerify",
+      "testParticipate"
     ]
 };
+
 Object.keys(allSimpleTests).forEach(function(k) {
     var obj = testContracts[k];
     contract(k, (accounts) => {
@@ -45,7 +52,6 @@ Object.keys(allSimpleTests).forEach(function(k) {
     });
 });
 
-
 // Random point on the alt_bn128 curve
 function RandomPoint () {
     const P = bigInt("21888242871839275222246405745257275088696311157297823662689037894645226208583");
@@ -62,11 +68,9 @@ function RandomPoint () {
     }
 }
 
-
 function CreateDummyTx(account, value) {
     return { from: account, value: value };
 }
-
 
 contract('Mixer', (accounts) => {
     it('Invalid and duplicate deposits', async () => {
@@ -78,41 +82,44 @@ contract('Mixer', (accounts) => {
         let instance = await Mixer.deployed();
 
         // This should succeed
-        let result = await instance.DepositEther(token, txObj.value, point.x, point.y, txObj);
+        let result = await instance.depositEther(token, txObj.value, point.x, point.y, txObj);
         assert.ok(result.receipt.status, "Bad deposit status with valid point");
 
         // This will fail because the point is already in a ring
         var ok = false;
-        result = await instance.DepositEther(token, txObj.value, point.x, point.y, txObj).catch(function(err) {
+        result = await instance.depositEther(token, txObj.value, point.x, point.y, txObj).catch(function(err) {
             assert.include(err.message, 'revert', 'Deposit with duplicate key should revert');
             ok = true;
         });
-        if( ! ok )
-            assert.fail("Deposit with duplicate key should revert");
+        if(!ok) {
+          assert.fail("Deposit with duplicate key should revert");
+        }
 
         // This will fail because the point is invalid
         point = RandomPoint();
         ok = false;
-        result = await instance.DepositEther(token, txObj.value, 123, point.y, txObj).catch(function(err) {
+        result = await instance.depositEther(token, txObj.value, 123, point.y, txObj).catch(function(err) {
             assert.include(err.message, 'revert', 'Deposit with invalid point should revert');
             ok = true;
         });
-        if( ! ok )
+        if(!ok) {
             assert.fail("Deposit with invalid point should have reverted!");
+        }
 
         // This will fail because the denomination is invalid
         ok = false;
-        result = await instance.DepositEther(token, 0, point.x, point.y, txObj).catch(function(err) {
+        result = await instance.depositEther(token, 0, point.x, point.y, txObj).catch(function(err) {
             assert.include(err.message, 'revert', 'Deposit with invalid denomination should revert');
             ok = true;
         });
-        if( ! ok )
+        if(!ok) {
             assert.fail("Deposit with invalid denomination should revert");
+        }
 
         // Then fill the ring with a remaining 3, otherwise further tests will fail
         for( var i = 0; i < 3; i++ ) {
             point = RandomPoint();
-            result = await instance.DepositEther(token, txObj.value, point.x, point.y, txObj);
+            result = await instance.depositEther(token, txObj.value, point.x, point.y, txObj);
         }
     });
 
@@ -124,25 +131,25 @@ contract('Mixer', (accounts) => {
         const owner = accounts[0];
         const token = 0;            // 0 = ether
         const txObj = { from: owner, value: txValue };
-
         const startingBalance = web3.eth.getBalance(instance.address);
         const ringSize = 4;
+        const logDepositEvent = 'LogMixerDeposit';
+        const logReadyEvent = 'LogMixerReady';
 
         // Deposit 4 times (the ring size) into the mixer
         // Verify:
         //  - Mixer accepts deposits
-        //  - Mixer emits MixerDeposit event for each deposit
+        //  - Mixer emits LogMixerDeposit event for each deposit
         //  - Last deposit also emits MixerReady message
         var i = 0;
         var results = [];
         var ring_guid = null;
         var total_gas = 0;
-        while( i < (ringSize * 2) )
-        {
+        while(i < (ringSize * 2)) {
             i++;
             // Deposit a random public key
             const point = RandomPoint();
-            let result = await instance.DepositEther(token, txValue, point.x, point.y, txObj);
+            let result = await instance.depositEther(token, txValue, point.x, point.y, txObj);
             assert.ok(result.receipt.status, "Bad deposit status");
             total_gas += result.receipt.gasUsed;
 
@@ -150,12 +157,12 @@ contract('Mixer', (accounts) => {
             const contractBalance = web3.eth.getBalance(instance.address);
             assert.equal(contractBalance.toString(), startingBalance.add(txValue * i).toString());
 
-            // MixerDeposit event should be triggered
-            const expectedMixerDeposit = result.logs.some(el => (el.event === 'MixerDeposit'));
-            assert.ok(expectedMixerDeposit, "MixerDeposit event was not emitted");
+            // A deposit event should be triggered
+            const expectedMixerDeposit = result.logs.some(el => (el.event === logDepositEvent));
+            assert.ok(expectedMixerDeposit, "Deposit event was not emitted");
 
             // Ring GUID should match the previous one
-            const depositEvent = result.logs.find(el => (el.event === 'MixerDeposit'));
+            const depositEvent = result.logs.find(el => (el.event === logDepositEvent));
             if( ring_guid !== null ) {
                 assert.equal(depositEvent.args.ring_id.toString(), ring_guid, "Ring GUID batch doesn't match");
             }
@@ -163,18 +170,18 @@ contract('Mixer', (accounts) => {
                 ring_guid = depositEvent.args.ring_id.toString();
             }
 
-            // For every N deposits, verify a MixerReady event has triggered
+            // For every N deposits, verify a ready event has triggered
             const isLast = 0 == (i % ringSize);
             if( isLast ) {
-                const expectedMixerReady = result.logs.some(el => (el.event === 'MixerReady'));
-                assert.ok(expectedMixerReady, "MixerReady event was not emitted");
+                const expectedMixerReady = result.logs.some(el => (el.event === logReadyEvent));
+                assert.ok(expectedMixerReady, "Ready event was not emitted");
 
-                const readyEvent = result.logs.find(el => (el.event === 'MixerReady'));
+                const readyEvent = result.logs.find(el => (el.event === logReadyEvent));
                 assert.equal(readyEvent.args.ring_id, ring_guid, "Ring GUID batch doesn't match");
 
                 ring_guid = null;
             }
         }
-        console.log("      Average Gas per Deposit: " + (total_gas / i));
+        console.log("\tAverage Gas per Deposit: " + (total_gas / i));
     });
 });


### PR DESCRIPTION
This PR acts as a cleanup of the Mobius code.

A saw many inconsistencies that make the code hard/annoying to read. Thus I implemented some "solidity good practices" extracted from: 
- https://solidity.readthedocs.io/en/develop/style-guide.html
- https://consensys.github.io/smart-contract-best-practices/recommendations/

Overall, here are the things I saw the most:
- Inconsistent spacing: `require ( ! ok )` is an example of what happened to be done. See: https://solidity.readthedocs.io/en/develop/style-guide.html#whitespace-in-expressions for further details on good practices. The spacing was inconsistent for functions, `if`, `for`, `require`...
- Capital letters for function names. This is confusing with the events names that are also declared using a capital letter. In order to fix it: I began **ALL** function name by a small letter (see: https://solidity.readthedocs.io/en/develop/style-guide.html#function-names), **AND** prefixed ALL event names by `Log` as suggested in https://consensys.github.io/smart-contract-best-practices/recommendations/#differentiate-functions-and-events
- Inconsistency in comment formatting. Sometimes, `/* */` was used for single lines comments, sometimes `//`. I tried to remove this inconsistency by adopting `//` for single lines comments, and keeping the `/**/` format for multiple line comments and comments preceding function declarations.
- Inconsistency in functions name. In general it is a good practice to prefix functions returning a boolean with `is`. However, not all functions followed this (some but not all, especially `SignatureValid` that verifies if a signature is valid. Thus it has been renamed accordingly).
- Order in function declaration (public functions declared first, internal and private at the end): see https://solidity.readthedocs.io/en/develop/style-guide.html#order-of-functions
- Many small function declarations followed the format:
```javascript
function tinyFunction()
    public
{
```
Which is pretty confusing I think. I would suggest, that we follow the style recommendation in the solidity web page and only do this for long function/event declarations/calls. (Same thing for contract/library declaration)
- Inconsistencies in line spacing: https://solidity.readthedocs.io/en/develop/style-guide.html#blank-lines Sometimes 1 line was used, sometimes, 2, sometimes none.... I would suggest 1 as mentioned in the solidity doc
- Inconsistencies in `if`. Sometimes, `if` bodies that only had 1 line were not surrounded by braces, sometimes they were. I added braces every time as it makes the code easier to read.

Moreover, I introduced some constants for the events value in the tests. I think this is better as it makes the code more flexible. If one needs to change the name of an event, one only needs to change the value of the constant. 
Finally, I would suggest that we adopt the convention `Test[FunctionName]` for the testing function. I didn't change it everywhere though.